### PR TITLE
Add hardening for invalid context being passed

### DIFF
--- a/lib/class-performant-translations-compat-provider.php
+++ b/lib/class-performant-translations-compat-provider.php
@@ -98,14 +98,14 @@ class Performant_Translations_Compat_Provider {
 	/**
 	 * Translates a plural string.
 	 *
-	 * @param string    $singular Singular translation.
-	 * @param string    $plural Plural translation.
-	 * @param int|float $count Count. Should be an integer, but some plugins pass floats.
-	 * @param string    $context Context.
+	 * @param string      $singular Singular translation.
+	 * @param string      $plural   Plural translation.
+	 * @param int|float   $count    Count. Should be an integer, but some plugins pass floats.
+	 * @param string|null $context  Context.
 	 * @return string Translation.
 	 */
 	public function translate_plural( $singular, $plural, $count = 1, $context = '' ) {
-		$translation = Ginger_MO::instance()->translate_plural( array( $singular, $plural ), (int) $count, $context, $this->textdomain );
+		$translation = Ginger_MO::instance()->translate_plural( array( $singular, $plural ), (int) $count, (string) $context, $this->textdomain );
 		if ( false !== $translation ) {
 			return $translation;
 		}
@@ -117,12 +117,12 @@ class Performant_Translations_Compat_Provider {
 	/**
 	 * Translates a singular string.
 	 *
-	 * @param string $singular Singular translation.
-	 * @param string $context Context.
+	 * @param string      $singular Singular translation.
+	 * @param string|null $context  Context.
 	 * @return string Translation.
 	 */
 	public function translate( $singular, $context = '' ) {
-		$translation = Ginger_MO::instance()->translate( $singular, $context, $this->textdomain );
+		$translation = Ginger_MO::instance()->translate( $singular, (string) $context, $this->textdomain );
 		if ( false !== $translation ) {
 			return $translation;
 		}


### PR DESCRIPTION
Some plugins cause calls like `_x('Foo, NULL, 'textdomain')`, which causes `null` to be passed down to `Ginger_MO`, which expects strings only. For these plugins `_doing_it_wrong()`, this extra hardening prevents PHP errors.