### PR TITLE
Regenerate PHP files when Loco Translate updates MO files

### DIFF
--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -239,6 +239,9 @@ class Performant_Translations {
 	/**
 	 * Regenerate preferred translation files when an MO file is updated in Loco Translate.
 	 *
+	 * This compatibility code is added out of courtesy and is not intended
+	 * to be merged into WordPress core.
+	 * 
 	 * @codeCoverageIgnore
 	 *
 	 * @param string $file Path to translation file.

--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -241,7 +241,7 @@ class Performant_Translations {
 	 *
 	 * This compatibility code is added out of courtesy and is not intended
 	 * to be merged into WordPress core.
-	 * 
+	 *
 	 * @codeCoverageIgnore
 	 *
 	 * @param string $file Path to translation file.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,5 +15,8 @@ parameters:
 		- build-cs/vendor/php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
 	bootstrapFiles:
 		- tests/phpstan/bootstrap.php
+	ignoreErrors:
+		# WordPress core includes a polyfill.
+		-	message: '/^Function str_ends_with not found\./'
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon


### PR DESCRIPTION
This improves compatibility with Loco Translate.

Whenever a translation file is edited there, the corresponding PHP/JSON translation file is regenerated.