### PR TITLE
Improve Query Monitor compatibility

### DIFF
--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -56,6 +56,18 @@ class Performant_Translations {
 			/** This filter is documented in wp-includes/l10n.php */
 			$mofile_preferred = apply_filters( 'load_textdomain_mofile', $mofile_preferred, $domain );
 
+			/**
+			 * Filters the file path for loading translations for the given text domain.
+			 *
+			 * The file could be an MO, JSON, or PHP file.
+			 *
+			 * @since 1.0.3
+			 *
+			 * @param string $file   Path to the translation file to load.
+			 * @param string $domain The text domain.
+			 */
+			$mofile_preferred = apply_filters( 'performant_translations_load_translation_file', $mofile_preferred, $domain );
+
 			$success = Ginger_MO::instance()->load( $mofile_preferred, $domain, $locale );
 
 			if ( $success ) {
@@ -74,6 +86,9 @@ class Performant_Translations {
 
 		/** This filter is documented in wp-includes/l10n.php */
 		$mofile = apply_filters( 'load_textdomain_mofile', $mofile, $domain );
+
+		/** This filter is documented in lib/class-performant-translations.php */
+		$mofile = apply_filters( 'performant_translations_load_translation_file', $mofile, $domain );
 
 		$success = Ginger_MO::instance()->load( $mofile, $domain, $locale );
 

--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -209,7 +209,7 @@ class Performant_Translations {
 			}
 
 			if ( file_exists( $file ) ) {
-				/** This filter is documented in lib/class-ginger-mo-translation-compat.php */
+				/** This filter is documented in lib/class-performant-translations.php */
 				$preferred_format = apply_filters( 'performant_translations_preferred_format', 'php' );
 				if ( ! in_array( $preferred_format, array( 'php', 'mo', 'json' ), true ) ) {
 					$preferred_format = 'php';
@@ -217,7 +217,7 @@ class Performant_Translations {
 
 				$mofile_preferred = str_replace( '.mo', ".$preferred_format", $file );
 
-				/** This filter is documented in lib/class-ginger-mo-translation-compat.php */
+				/** This filter is documented in lib/class-performant-translations.php */
 				$convert = apply_filters( 'performant_translations_convert_files', true );
 
 				if ( 'mo' !== $preferred_format && $convert ) {
@@ -258,7 +258,7 @@ class Performant_Translations {
 			return;
 		}
 
-		/** This filter is documented in lib/class-ginger-mo-translation-compat.php */
+		/** This filter is documented in lib/class-performant-translations.php */
 		$preferred_format = apply_filters( 'performant_translations_preferred_format', 'php' );
 		if ( ! in_array( $preferred_format, array( 'php', 'mo', 'json' ), true ) ) {
 			$preferred_format = 'php';
@@ -266,7 +266,7 @@ class Performant_Translations {
 
 		$mofile_preferred = str_replace( '.mo', ".$preferred_format", $file );
 
-		/** This filter is documented in lib/class-ginger-mo-translation-compat.php */
+		/** This filter is documented in lib/class-performant-translations.php */
 		$convert = apply_filters( 'performant_translations_convert_files', true );
 
 		if ( 'mo' !== $preferred_format && $convert ) {

--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -35,12 +35,6 @@ class Performant_Translations {
 		// the locale.
 		Ginger_MO::instance()->set_locale( $locale );
 
-		/** This action is documented in wp-includes/l10n.php */
-		do_action( 'load_textdomain', $domain, $mofile );
-
-		/** This filter is documented in wp-includes/l10n.php */
-		$mofile = apply_filters( 'load_textdomain_mofile', $mofile, $domain );
-
 		/**
 		 * Filters the preferred file format for translation files.
 		 *
@@ -56,6 +50,12 @@ class Performant_Translations {
 		$mofile_preferred = str_replace( '.mo', ".$preferred_format", $mofile );
 
 		if ( 'mo' !== $preferred_format ) {
+			/** This action is documented in wp-includes/l10n.php */
+			do_action( 'load_textdomain', $domain, $mofile_preferred );
+
+			/** This filter is documented in wp-includes/l10n.php */
+			$mofile_preferred = apply_filters( 'load_textdomain_mofile', $mofile_preferred, $domain );
+
 			$success = Ginger_MO::instance()->load( $mofile_preferred, $domain, $locale );
 
 			if ( $success ) {
@@ -65,9 +65,15 @@ class Performant_Translations {
 
 				$wp_textdomain_registry->set( $domain, $locale, dirname( $mofile ) );
 
-				return $success;
+				return true;
 			}
 		}
+
+		/** This action is documented in wp-includes/l10n.php */
+		do_action( 'load_textdomain', $domain, $mofile );
+
+		/** This filter is documented in wp-includes/l10n.php */
+		$mofile = apply_filters( 'load_textdomain_mofile', $mofile, $domain );
 
 		$success = Ginger_MO::instance()->load( $mofile, $domain, $locale );
 

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,11 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 
 For the plugin's full changelog, please see [the Releases page on GitHub](https://github.com/swissspidy/performant-translations/releases).
 
+= 1.0.3 =
+
+* Enhancement: Improved compatibility with Query Monitor by running `load_textdomain` / `load_textdomain_mofile` hooks later.
+* Enhancement: Added new `performant_translations_load_translation_file` filter.
+
 = 1.0.2 =
 
 * Fixed: Add hardening for invalid values being passed to translation functions.


### PR DESCRIPTION
Fire `load_textdomain` action and apply `load_textdomain_mofile` filter for PHP files too, so that the report in Query Monitor looks correct:

<img width="1536" alt="Screenshot 2023-09-03 at 15 14 30" src="https://github.com/swissspidy/performant-translations/assets/841956/9e38d98c-f723-47d5-9064-8547beb29284">

Might be confusing to use `load_textdomain_mofile` for PHP files. Maybe a new filter similar to `load_script_translation_file` is needed? QM would need to use it.

Edit: added a new `performant_translations_load_translation_file` filter