### PR TITLE
Add workaround for potential file permission issues

### DIFF
--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -118,8 +118,8 @@ class Performant_Translations {
 
 				if ( str_contains( $modir, WP_PLUGIN_DIR ) ) {
 					$new_location = WP_LANG_DIR . '/plugins/' . $filename;
-				} elseif ( str_contains( $modir, get_template_directory() ) ) {
-					$new_location = WP_LANG_DIR . '/themes/' . $filename;
+				} elseif ( str_contains( $modir, basename( get_stylesheet_directory() ) ) ) {
+					$new_location = WP_LANG_DIR . '/themes/' . basename( get_stylesheet_directory() ) . '-' . $filename;
 				}
 
 				if ( '' !== $new_location ) {
@@ -209,8 +209,8 @@ class Performant_Translations {
 
 						if ( str_contains( $modir, WP_PLUGIN_DIR ) ) {
 							$new_location = WP_LANG_DIR . '/plugins/' . $filename;
-						} elseif ( str_contains( $modir, get_template_directory() ) ) {
-							$new_location = WP_LANG_DIR . '/themes/' . $filename;
+						} elseif ( str_contains( $modir, basename( get_stylesheet_directory() ) ) ) {
+							$new_location = WP_LANG_DIR . '/themes/' . basename( get_stylesheet_directory() ) . '-' . $filename;
 						}
 
 						if ( '' !== $new_location ) {

--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -76,6 +76,7 @@ class Performant_Translations {
 			$preferred_format = 'php';
 		}
 
+		$modir            = dirname( $mofile );
 		$mofile_preferred = "$mofile.$preferred_format";
 
 		if ( 'mo' !== $preferred_format || str_ends_with( $mofile, $preferred_format ) ) {
@@ -108,9 +109,42 @@ class Performant_Translations {
 				unset( $l10n[ $domain ] );
 				$l10n[ $domain ] = new Performant_Translations_Compat_Provider( $domain );
 
-				$wp_textdomain_registry->set( $domain, $locale, dirname( $mofile ) );
+				$wp_textdomain_registry->set( $domain, $locale, $modir );
 
 				return true;
+			} elseif ( str_ends_with( $mofile, 'mo' ) ) {
+				$filename     = basename( $mofile_preferred );
+				$new_location = '';
+
+				if ( str_contains( $modir, WP_PLUGIN_DIR ) ) {
+					$new_location = WP_LANG_DIR . '/plugins/' . $filename;
+				} elseif ( str_contains( $modir, get_template_directory() ) ) {
+					$new_location = WP_LANG_DIR . '/themes/' . $filename;
+				}
+
+				if ( '' !== $new_location ) {
+					/** This filter is documented in wp-includes/l10n.php */
+					$new_location = apply_filters( 'load_textdomain_mofile', $new_location, $domain );
+
+					/** This filter is documented in lib/class-performant-translations.php */
+					$new_location = apply_filters( 'performant_translations_load_translation_file', $new_location, $domain );
+
+					$success = Ginger_MO::instance()->load( $new_location, $domain, $locale );
+
+					if ( $success ) {
+						if ( isset( $l10n[ $domain ] ) && $l10n[ $domain ] instanceof MO ) {
+							Ginger_MO::instance()->load( $l10n[ $domain ]->get_filename(), $domain, $locale );
+						}
+
+						// Unset Noop_Translations reference in get_translations_for_domain.
+						unset( $l10n[ $domain ] );
+						$l10n[ $domain ] = new Performant_Translations_Compat_Provider( $domain );
+
+						$wp_textdomain_registry->set( $domain, $locale, dirname( $new_location ) );
+
+						return true;
+					}
+				}
 			}
 		}
 
@@ -156,14 +190,13 @@ class Performant_Translations {
 						require_once ABSPATH . '/wp-admin/includes/file.php';
 					}
 
-					$dir           = dirname( $mofile_preferred );
 					$filename      = basename( $mofile_preferred );
 					$write_success = false;
 
 					if ( true === WP_Filesystem() ) {
 						$write_success = $wp_filesystem->put_contents( $mofile_preferred, $contents, FS_CHMOD_FILE );
 					} else {
-						if ( is_writable( $dir ) ) {
+						if ( is_writable( $modir ) ) {
 							$write_success = (bool) file_put_contents( $mofile_preferred, $contents, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 						}
 					}
@@ -174,9 +207,9 @@ class Performant_Translations {
 					if ( ! $write_success ) {
 						$new_location = '';
 
-						if ( str_contains( $dir, WP_PLUGIN_DIR ) ) {
+						if ( str_contains( $modir, WP_PLUGIN_DIR ) ) {
 							$new_location = WP_LANG_DIR . '/plugins/' . $filename;
-						} elseif ( str_contains( $dir, get_template_directory() ) ) {
+						} elseif ( str_contains( $modir, get_template_directory() ) ) {
 							$new_location = WP_LANG_DIR . '/themes/' . $filename;
 						}
 
@@ -184,7 +217,7 @@ class Performant_Translations {
 							if ( true === WP_Filesystem() ) {
 								$wp_filesystem->put_contents( $new_location, $contents, FS_CHMOD_FILE );
 							} else {
-								if ( is_writable( $dir ) ) {
+								if ( is_writable( $modir ) ) {
 									(bool) file_put_contents( $new_location, $contents, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 								}
 							}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,8 +16,9 @@ parameters:
 	bootstrapFiles:
 		- tests/phpstan/bootstrap.php
 	ignoreErrors:
-		# WordPress core includes a polyfill.
+		# WordPress core includes a polyfill for these.
 		- message: '/^Function str_ends_with not found\./'
+		- message: '/^Function str_contains not found\./'
 		# We explicitly want to test with improper values.
 		- message: '/^Parameter #\d \$(text|single|plural|context) of function (__|_n|_x) expects string, null given\.$/'
 		- message: '/^Parameter #3 \$number of function _n expects int, float given\.$/'

--- a/tests/phpunit/integration/tests/Performant_Translations_Tests.php
+++ b/tests/phpunit/integration/tests/Performant_Translations_Tests.php
@@ -164,6 +164,37 @@ class Performant_Translations_Tests extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
+	public function test_load_textdomain_creates_and_reads_php_files_despite_permission_issues() {
+		// Create a non-writable PHP version to simulate issues with writing to the same directory.
+		file_put_contents( WP_PLUGIN_DIR . '/custom-internationalized-plugin/languages/custom-internationalized-plugin-de_DE.mo.php', '' );
+		chmod( WP_PLUGIN_DIR . '/custom-internationalized-plugin/languages/custom-internationalized-plugin-de_DE.mo.php', 0000 );
+
+		$load_mo_successful = load_textdomain(
+			'custom-internationalized-plugin',
+			WP_PLUGIN_DIR . '/custom-internationalized-plugin/languages/custom-internationalized-plugin-de_DE.mo'
+		);
+
+		$unload_mo_successful = unload_textdomain( 'custom-internationalized-plugin' );
+
+		$load_php_successful = load_textdomain( 'custom-internationalized-plugin', WP_LANG_DIR . '/plugins/custom-internationalized-plugin-de_DE.mo.php' );
+
+		$unload_php_successful = unload_textdomain( 'custom-internationalized-plugin' );
+
+		$this->unlink( WP_PLUGIN_DIR . '/custom-internationalized-plugin/languages/custom-internationalized-plugin-de_DE.mo.php' );
+
+		$this->assertTrue( $load_mo_successful, 'MO file not successfully loaded' );
+		$this->assertTrue( $unload_mo_successful );
+		$this->assertFileDoesNotExist( WP_PLUGIN_DIR . '/custom-internationalized-plugin/custom-internationalized-plugin-de_DE.mo.php' );
+		$this->assertFileExists( WP_LANG_DIR . '/plugins/custom-internationalized-plugin-de_DE.mo.php' );
+		$this->assertTrue( $load_php_successful, 'PHP file not successfully loaded' );
+		$this->assertTrue( $unload_php_successful );
+	}
+
+	/**
+	 * @covers ::load_textdomain
+	 *
+	 * @return void
+	 */
 	public function test_load_textdomain_creates_and_reads_php_files_if_filtered_format_is_unsupported() {
 		add_filter(
 			'performant_translations_preferred_format',


### PR DESCRIPTION
When loading a file such as `wp-content/plugins/foo-plugin/languages/foo-plugin-de_DE.mo`
If `wp-content/plugins/foo-plugin/languages/foo-plugin-de_DE.mo.php` cannot be created
Try creating `wp-content/languages/plugins/foo-plugin-de_DE.mo.php` instead

When loading a file such as `wp-content/plugins/foo-plugin/languages/foo-plugin-de_DE.mo` again
Look up `wp-content/plugins/foo-plugin/languages/foo-plugin-de_DE.mo.php`
And then look up `wp-content/languages/plugins/foo-plugin-de_DE.mo.php`

Ditto for themes (note the change in file name!):

When loading a file such as `wp-content/themes/foo-theme/languages/de_DE.mo`
If `wp-content/themes/foo-theme/languages/de_DE.mo.php` cannot be created
Try creating `wp-content/languages/themes/foo-theme-de_DE.mo.php` instead

When loading a file such as `wp-content/themes/foo-theme/languages/de_DE.mo` again
Look up `wp-content/themes/foo-theme/languages/de_DE.mo.php`
And then look up `wp-content/languages/themes/foo-theme-de_DE.mo.php`

Fixes #108