### PR TITLE
Regenerate all core translation files upon translation update

### DIFF
--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -261,41 +261,47 @@ class Performant_Translations {
 		}
 
 		foreach ( $hook_extra['translations'] as $translation ) {
+			$files = array();
 			switch ( $translation['type'] ) {
 				case 'plugin':
-					$file = WP_LANG_DIR . '/plugins/' . $translation['slug'] . '-' . $translation['language'] . '.mo';
+					$files[] = WP_LANG_DIR . '/plugins/' . $translation['slug'] . '-' . $translation['language'] . '.mo';
 					break;
 				case 'theme':
-					$file = WP_LANG_DIR . '/themes/' . $translation['slug'] . '-' . $translation['language'] . '.mo';
+					$files[] = WP_LANG_DIR . '/themes/' . $translation['slug'] . '-' . $translation['language'] . '.mo';
 					break;
 				default:
-					$file = WP_LANG_DIR . '/' . $translation['language'] . '.mo';
+					$files[] = WP_LANG_DIR . '/' . $translation['language'] . '.mo';
+					$files[] = WP_LANG_DIR . '/admin-' . $translation['language'] . '.mo';
+					$files[] = WP_LANG_DIR . '/admin-network-' . $translation['language'] . '.mo';
+					$files[] = WP_LANG_DIR . '/continents-cities-' . $translation['language'] . '.mo';
 					break;
 			}
 
-			if ( file_exists( $file ) ) {
-				/** This filter is documented in lib/class-performant-translations.php */
-				$preferred_format = apply_filters( 'performant_translations_preferred_format', 'php' );
-				if ( ! in_array( $preferred_format, array( 'php', 'mo' ), true ) ) {
-					$preferred_format = 'php';
-				}
-
-				$mofile_preferred = "$file.$preferred_format";
-
-				/** This filter is documented in lib/class-performant-translations.php */
-				$convert = apply_filters( 'performant_translations_convert_files', true );
-
-				if ( 'mo' !== $preferred_format && $convert ) {
-					$contents = Ginger_MO_Translation_File::transform( $file, $preferred_format );
-
-					if ( false === $contents ) {
-						return;
+			foreach ( $files as $file ) {
+				if ( file_exists( $file ) ) {
+					/** This filter is documented in lib/class-performant-translations.php */
+					$preferred_format = apply_filters( 'performant_translations_preferred_format', 'php' );
+					if ( ! in_array( $preferred_format, array( 'php', 'mo' ), true ) ) {
+						$preferred_format = 'php';
 					}
 
-					if ( true === $upgrader->fs_connect( array( dirname( $file ) ) ) ) {
-						$wp_filesystem->put_contents( $mofile_preferred, $contents, FS_CHMOD_FILE );
-					} else {
-						file_put_contents( $mofile_preferred, $contents, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+					$mofile_preferred = "$file.$preferred_format";
+
+					/** This filter is documented in lib/class-performant-translations.php */
+					$convert = apply_filters( 'performant_translations_convert_files', true );
+
+					if ( 'mo' !== $preferred_format && $convert ) {
+						$contents = Ginger_MO_Translation_File::transform( $file, $preferred_format );
+
+						if ( false === $contents ) {
+							return;
+						}
+
+						if ( true === $upgrader->fs_connect( array( dirname( $file ) ) ) ) {
+							$wp_filesystem->put_contents( $mofile_preferred, $contents, FS_CHMOD_FILE );
+						} else {
+							file_put_contents( $mofile_preferred, $contents, LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+						}
 					}
 				}
 			}

--- a/tests/phpunit/integration/tests/Performant_Translations_Tests.php
+++ b/tests/phpunit/integration/tests/Performant_Translations_Tests.php
@@ -15,6 +15,9 @@ class Performant_Translations_Tests extends WP_UnitTestCase {
 			WP_LANG_DIR . '/plugins/internationalized-plugin-de_DE.mo.php',
 			WP_LANG_DIR . '/themes/internationalized-theme-de_DE.mo.php',
 			WP_LANG_DIR . '/de_DE.mo.php',
+			WP_LANG_DIR . '/admin-de_DE.mo.php',
+			WP_LANG_DIR . '/admin-network-de_DE.mo.php',
+			WP_LANG_DIR . '/continents-cities-de_DE.mo.php',
 		);
 
 		foreach ( $generated_translation_files as $file ) {
@@ -510,7 +513,7 @@ class Performant_Translations_Tests extends WP_UnitTestCase {
 				(object) array(
 					'type'     => 'core',
 					'slug'     => 'default',
-					'language' => 'de_DE',
+					'language' => 'es_ES',
 					'version'  => '99.9.9',
 					'package'  => '/tmp/notused.zip',
 				),
@@ -523,7 +526,10 @@ class Performant_Translations_Tests extends WP_UnitTestCase {
 
 		$this->assertFileExists( WP_LANG_DIR . '/plugins/internationalized-plugin-de_DE.mo.php' );
 		$this->assertFileExists( WP_LANG_DIR . '/themes/internationalized-theme-de_DE.mo.php' );
-		$this->assertFileExists( WP_LANG_DIR . '/de_DE.mo.php' );
+		$this->assertFileExists( WP_LANG_DIR . '/es_ES.mo.php' );
+		$this->assertFileExists( WP_LANG_DIR . '/admin-es_ES.mo.php' );
+		$this->assertFileExists( WP_LANG_DIR . '/admin-network-es_ES.mo.php' );
+		$this->assertFileExists( WP_LANG_DIR . '/continents-cities-es_ES.mo.php' );
 	}
 
 	/**


### PR DESCRIPTION
Core is a special case because translations are split up in multiple files.

Upon translation updates only the main file was updated, but not the others.