### PR TITLE
Add filter to allow hiding plugin version

### DIFF
--- a/lib/class-performant-translations.php
+++ b/lib/class-performant-translations.php
@@ -379,6 +379,9 @@ class Performant_Translations {
 	 * @return void
 	 */
 	public static function add_generator_tag() {
+		if ( apply_filters( 'performant_translations_hide_version', false ) ) {
+			return;
+		}
 		echo '<meta name="generator" content="Performant Translations ' . esc_attr( PERFORMANT_TRANSLATIONS_VERSION ) . '">' . "\n";
 	}
 


### PR DESCRIPTION
Hi @swissspidy 

Would you please consider merging this PR to allow removing the generator meta tag from the `<head>`? The plugin is working well for us but we always remove plugin version information for security, so I've added a filter modelled on [Yoast's filter for version removal](https://developer.yoast.com/customization/yoast-seo-premium/hiding-version-number/).

Usage: `add_filter( 'performant_translations_hide_version', '__return_true' );`

Thanks, Matt