### PR TITLE
Install svn in GitHub Actions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -97,6 +97,11 @@ jobs:
             - name: Shutdown default MySQL service
               run: sudo service mysql stop
 
+            - name: Install svn
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y subversion
+
             - name: Set up tests
               run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true
 


### PR DESCRIPTION
 It is no longer available by default and needs to be installed manually. Currently still used by the `install-wp-tests.sh` script.