### PR TITLE
Add `performanceteam` as contributor

### DIFF
--- a/performant-translations.php
+++ b/performant-translations.php
@@ -5,7 +5,7 @@
  * Description: Making internationalization/localization in WordPress faster than ever before.
  * Version:     1.2.0
  * Network:     true
- * Author:      performanceteam
+ * Author:      WordPress Performance Team
  * Author URI:  https://make.wordpress.org/performance/
  * License:     GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt

--- a/performant-translations.php
+++ b/performant-translations.php
@@ -5,7 +5,7 @@
  * Description: Making internationalization/localization in WordPress faster than ever before.
  * Version:     1.2.0
  * Network:     true
- * Author:      WordPress Performance Team
+ * Author:      performanceteam
  * Author URI:  https://make.wordpress.org/performance/
  * License:     GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,6 @@
 === Performant Translations ===
 
+Author:      performanceteam
 Contributors:      swissspidy, dd32, wordpressdotorg
 Tested up to:      6.8
 Stable tag:        1.2.0

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,6 @@
 === Performant Translations ===
 
-Author:      performanceteam
-Contributors:      swissspidy, dd32, wordpressdotorg
+Contributors:      swissspidy, dd32, wordpressdotorg, performanceteam
 Tested up to:      6.8
 Stable tag:        1.2.0
 License:           GPL-2.0+


### PR DESCRIPTION
This pull request includes a minor update to the `performant-translations.php` file. The change updates the `Author` field to replace "WordPress Performance Team" with "performanceteam."

Note that after updating this on WPORG that you will also need to follow the steps on https://developer.wordpress.org/plugins/wordpress-org/transferring-your-plugin-to-a-new-owner/ so that https://wordpress.org/plugins/performant-translations/ gets transferred to the `performanceteam` user and properly represented as "By WordPress Performance Team".